### PR TITLE
[Fixbug] 让 pluginsystem 可以使用

### DIFF
--- a/r5sdk/r5dev/launcher/IApplication.cpp
+++ b/r5sdk/r5dev/launcher/IApplication.cpp
@@ -103,7 +103,7 @@ bool CModAppSystemGroup::StaticCreate(CModAppSystemGroup* pModAppSystemGroup)
 	g_pFactory->AddFactory(FACTORY_INTERFACE_VERSION, g_pFactory);
 	g_pFactory->AddFactory(INTERFACEVERSION_PLUGINSYSTEM, g_pPluginSystem);
 
-	InitPluginSystem(pModAppSystemGroup);// ÐÞ¸Ä
+	InitPluginSystem(pModAppSystemGroup);
 	//CALL_PLUGIN_CALLBACKS(g_pPluginSystem->GetCreateCallbacks(), pModAppSystemGroup);
 
 	g_pDebugOverlay = g_pFactory->GetFactoryPtr(VDEBUG_OVERLAY_INTERFACE_VERSION, false).RCast<CIVDebugOverlay*>();

--- a/r5sdk/r5dev/launcher/IApplication.cpp
+++ b/r5sdk/r5dev/launcher/IApplication.cpp
@@ -103,7 +103,7 @@ bool CModAppSystemGroup::StaticCreate(CModAppSystemGroup* pModAppSystemGroup)
 	g_pFactory->AddFactory(FACTORY_INTERFACE_VERSION, g_pFactory);
 	g_pFactory->AddFactory(INTERFACEVERSION_PLUGINSYSTEM, g_pPluginSystem);
 
-	//InitPluginSystem(pModAppSystemGroup);
+	InitPluginSystem(pModAppSystemGroup);// ÐÞ¸Ä
 	//CALL_PLUGIN_CALLBACKS(g_pPluginSystem->GetCreateCallbacks(), pModAppSystemGroup);
 
 	g_pDebugOverlay = g_pFactory->GetFactoryPtr(VDEBUG_OVERLAY_INTERFACE_VERSION, false).RCast<CIVDebugOverlay*>();

--- a/r5sdk/r5dev/pluginsystem/pluginsystem.cpp
+++ b/r5sdk/r5dev/pluginsystem/pluginsystem.cpp
@@ -31,21 +31,9 @@ void CPluginSystem::PluginSystem_Init()
 				path.has_extension() &&
 				path.extension().compare(".dll") == 0)
 			{
-				/* 不检测重复
-				bool addInstance = true;
-				for (auto& inst : pluginInstances)
-				{
-					if (inst.m_svPluginFullPath.compare(pathString) == 0)
-						addInstance = false;
-				}
-				*/
-
-				//if (addInstance)
-				//{
-					PluginInstance_t plugInst = PluginInstance_t(path.filename().u8string(), pathString + path.filename().u8string());
-					pluginInstances.push_back(plugInst);
-					DevMsg(eDLL_T::ENGINE, "Added plugin: %s\n", plugInst.m_svPluginFullPath.c_str());
-				//}
+				PluginInstance_t plugInst = PluginInstance_t(path.filename().u8string(), pathString + path.filename().u8string());
+				pluginInstances.push_back(plugInst);
+				DevMsg(eDLL_T::ENGINE, "Added plugin: %s\n", plugInst.m_svPluginFullPath.c_str());
 			}
 		}
 	}
@@ -67,15 +55,6 @@ bool CPluginSystem::LoadPluginInstance(PluginInstance_t& pluginInst)
 		return false;
 
 	CModule pluginModule = CModule(pluginInst.m_svPluginName);
-
-	/* 用不到
-	// Pass selfModule here on load function, we have to do this because local listen/dedi/client dll's are called different, refer to a comment on the pluginsdk.
-	auto onLoadFn = pluginModule.GetExportedFunction("PluginInstance_OnLoad").RCast<PluginInstance_t::OnLoad>();
-	Assert(onLoadFn);
-
-	if (!onLoadFn(pluginInst.m_svPluginName.c_str()))
-		return false;
-	*/
 
 	pluginInst.m_hModule = pluginModule;
 

--- a/r5sdk/r5dev/pluginsystem/pluginsystem.cpp
+++ b/r5sdk/r5dev/pluginsystem/pluginsystem.cpp
@@ -31,15 +31,21 @@ void CPluginSystem::PluginSystem_Init()
 				path.has_extension() &&
 				path.extension().compare(".dll") == 0)
 			{
+				/* 不检测重复
 				bool addInstance = true;
 				for (auto& inst : pluginInstances)
 				{
 					if (inst.m_svPluginFullPath.compare(pathString) == 0)
 						addInstance = false;
 				}
+				*/
 
-				if (addInstance)
-					pluginInstances.push_back(PluginInstance_t(path.filename().u8string(), pathString));
+				//if (addInstance)
+				//{
+					PluginInstance_t plugInst = PluginInstance_t(path.filename().u8string(), pathString + path.filename().u8string());
+					pluginInstances.push_back(plugInst);
+					DevMsg(eDLL_T::ENGINE, "Added plugin: %s\n", plugInst.m_svPluginFullPath.c_str());
+				//}
 			}
 		}
 	}
@@ -56,20 +62,20 @@ bool CPluginSystem::LoadPluginInstance(PluginInstance_t& pluginInst)
 		return false;
 
 	HMODULE loadedPlugin = LoadLibraryA(pluginInst.m_svPluginFullPath.c_str());
+
 	if (loadedPlugin == INVALID_HANDLE_VALUE || loadedPlugin == 0)
 		return false;
 
 	CModule pluginModule = CModule(pluginInst.m_svPluginName);
 
+	/* 用不到
 	// Pass selfModule here on load function, we have to do this because local listen/dedi/client dll's are called different, refer to a comment on the pluginsdk.
 	auto onLoadFn = pluginModule.GetExportedFunction("PluginInstance_OnLoad").RCast<PluginInstance_t::OnLoad>();
 	Assert(onLoadFn);
 
 	if (!onLoadFn(pluginInst.m_svPluginName.c_str()))
-	{
-		FreeLibrary(loadedPlugin);
 		return false;
-	}
+	*/
 
 	pluginInst.m_hModule = pluginModule;
 


### PR DESCRIPTION
将dll插件放在 bin\x64_retail\plugins\ 以使用
r5sdk库在4月禁用了这个功能，经过修复已经可以使用